### PR TITLE
PROD-7131: Adding new App permissions in Golang

### DIFF
--- a/sdkms/common_generated.go
+++ b/sdkms/common_generated.go
@@ -504,6 +504,10 @@ const (
 	AppPermissionsMaskdecrypt
 	AppPermissionsAudit
 	AppPermissionsTransform
+	AppPermissionsCreateKey
+	AppPermissionsDestroyKey
+	AppPermissionsGetPublicKey
+	AppPermissionsGetInfo
 )
 
 // MarshalJSON converts AppPermissions to an array of strings


### PR DESCRIPTION
According to this API review doc: https://fortanix.atlassian.net/wiki/spaces/PROD/pages/2850357271/API+Review+Google+EKM+Control+Plane+service

I have added new enum values of `AppPermissions` 