### PR TITLE
Regenerate Go SDK to fix incorrect code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,16 @@ go 1.18
 // Incorrectly published v0.3.0 as a patch (v0.2.6)
 retract v0.2.6
 
+// Incorrectly generated code
+retract v0.3.0
+
+// Incorrectly generated code
+retract v0.3.1
+
+// Incorrectly generated code
+retract v0.3.2
+
+// Incorrectly generated code
+retract v0.3.3
+
 require github.com/pkg/errors v0.8.1

--- a/sdkms/accounts_generated.go
+++ b/sdkms/accounts_generated.go
@@ -540,8 +540,6 @@ type GetAccountParams struct {
 func (x GetAccountParams) urlEncode(v map[string][]string) error {
 	if x.WithTotals != nil {
 		v["with_totals"] = []string{fmt.Sprintf("%v", *x.WithTotals)}
-	} else {
-		v["with_totals"] = []string{"false"}
 	}
 	if x.PreviousID != nil {
 		v["previous_id"] = []string{fmt.Sprintf("%v", *x.PreviousID)}

--- a/sdkms/apps_generated.go
+++ b/sdkms/apps_generated.go
@@ -428,8 +428,6 @@ func (x ListAppsParams) urlEncode(v map[string][]string) error {
 	}
 	if x.GroupPermissions != nil {
 		v["group_permissions"] = []string{fmt.Sprintf("%v", *x.GroupPermissions)}
-	} else {
-		v["group_permissions"] = []string{"false"}
 	}
 	if x.Role != nil {
 		v["role"] = []string{fmt.Sprintf("%v", *x.Role)}

--- a/sdkms/batch_generated.go
+++ b/sdkms/batch_generated.go
@@ -1,0 +1,172 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package sdkms
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+type BatchExecutionType string
+
+// List of supported BatchExecutionType values
+const (
+	BatchExecutionTypeSerial    BatchExecutionType = "Serial"
+	BatchExecutionTypeUnordered BatchExecutionType = "Unordered"
+)
+
+type BatchRequest struct {
+	Batch      *BatchRequestList
+	SingleItem *BatchRequestItem
+}
+
+func (x BatchRequest) MarshalJSON() ([]byte, error) {
+	if err := checkEnumPointers(
+		"BatchRequest",
+		[]bool{x.Batch != nil,
+			x.SingleItem != nil}); err != nil {
+		return nil, err
+	}
+	var obj struct {
+		Batch      *BatchRequestList `json:"Batch,omitempty"`
+		SingleItem *BatchRequestItem `json:"SingleItem,omitempty"`
+	}
+	obj.Batch = x.Batch
+	obj.SingleItem = x.SingleItem
+	return json.Marshal(obj)
+}
+func (x *BatchRequest) UnmarshalJSON(data []byte) error {
+	x.Batch = nil
+	x.SingleItem = nil
+	var obj struct {
+		Batch      *BatchRequestList `json:"Batch,omitempty"`
+		SingleItem *BatchRequestItem `json:"SingleItem,omitempty"`
+	}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	x.Batch = obj.Batch
+	x.SingleItem = obj.SingleItem
+	return nil
+}
+
+type BatchRequestItem struct {
+	Method    string      `json:"method"`
+	Operation string      `json:"operation"`
+	Body      interface{} `json:"body,omitempty"`
+}
+
+type BatchRequestList struct {
+	BatchExecutionType BatchExecutionType `json:"batch_execution_type"`
+	Items              []BatchRequest     `json:"items"`
+}
+
+type BatchResponse struct {
+	Batch      *BatchResponseList
+	SingleItem *BatchResponseObject
+}
+
+func (x BatchResponse) MarshalJSON() ([]byte, error) {
+	if err := checkEnumPointers(
+		"BatchResponse",
+		[]bool{x.Batch != nil,
+			x.SingleItem != nil}); err != nil {
+		return nil, err
+	}
+	var obj struct {
+		Batch      *BatchResponseList   `json:"Batch,omitempty"`
+		SingleItem *BatchResponseObject `json:"SingleItem,omitempty"`
+	}
+	obj.Batch = x.Batch
+	obj.SingleItem = x.SingleItem
+	return json.Marshal(obj)
+}
+func (x *BatchResponse) UnmarshalJSON(data []byte) error {
+	x.Batch = nil
+	x.SingleItem = nil
+	var obj struct {
+		Batch      *BatchResponseList   `json:"Batch,omitempty"`
+		SingleItem *BatchResponseObject `json:"SingleItem,omitempty"`
+	}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	x.Batch = obj.Batch
+	x.SingleItem = obj.SingleItem
+	return nil
+}
+
+type BatchResponseList struct {
+	Items []BatchResponse `json:"items"`
+}
+
+type BatchResponseObject struct {
+	Result  *BatchResponseObjectResult
+	Skipped *BatchResponseObjectSkipped
+}
+type BatchResponseObjectResult struct {
+	Status uint16      `json:"status"`
+	Body   interface{} `json:"body,omitempty"`
+}
+type BatchResponseObjectSkipped struct {
+	Reason string `json:"reason"`
+}
+
+func (x BatchResponseObject) MarshalJSON() ([]byte, error) {
+	if err := checkEnumPointers(
+		"BatchResponseObject",
+		[]bool{x.Result != nil,
+			x.Skipped != nil}); err != nil {
+		return nil, err
+	}
+	var obj struct {
+		Result  *BatchResponseObjectResult  `json:"Result,omitempty"`
+		Skipped *BatchResponseObjectSkipped `json:"Skipped,omitempty"`
+	}
+	obj.Result = x.Result
+	obj.Skipped = x.Skipped
+	return json.Marshal(obj)
+}
+func (x *BatchResponseObject) UnmarshalJSON(data []byte) error {
+	x.Result = nil
+	x.Skipped = nil
+	var obj struct {
+		Result  *BatchResponseObjectResult  `json:"Result,omitempty"`
+		Skipped *BatchResponseObjectSkipped `json:"Skipped,omitempty"`
+	}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	x.Result = obj.Result
+	x.Skipped = obj.Skipped
+	return nil
+}
+
+// Create a new batch request
+func (c *Client) Batch(ctx context.Context, body BatchRequest) (*BatchResponse, error) {
+	u := "/batch/v1"
+	var r BatchResponse
+	if err := c.fetch(ctx, http.MethodPost, u, &body, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func (c *Client) RequestApprovalToBatch(
+	ctx context.Context,
+	body BatchRequest,
+	description *string) (*ApprovalRequest, error) {
+	u := "/batch/v1"
+	req := ApprovalRequestRequest{
+		Method:      someString(http.MethodPost),
+		Operation:   &u,
+		Body:        &body,
+		Description: description,
+	}
+	return c.CreateApprovalRequest(ctx, req)
+}

--- a/sdkms/common_generated.go
+++ b/sdkms/common_generated.go
@@ -504,10 +504,6 @@ const (
 	AppPermissionsMaskdecrypt
 	AppPermissionsAudit
 	AppPermissionsTransform
-	AppPermissionsCreateKey
-	AppPermissionsDestroyKey
-	AppPermissionsGetPublicKey
-	AppPermissionsGetInfo
 )
 
 // MarshalJSON converts AppPermissions to an array of strings
@@ -558,18 +554,6 @@ func (x AppPermissions) MarshalJSON() ([]byte, error) {
 	if x&AppPermissionsTransform == AppPermissionsTransform {
 		s = append(s, "TRANSFORM")
 	}
-	if x&AppPermissionsCreateKey == AppPermissionsCreateKey {
-		s = append(s, "CREATEKEY")
-	}
-	if x&AppPermissionsDestroyKey == AppPermissionsDestroyKey {
-		s = append(s, "DESTROYKEY")
-	}
-	if x&AppPermissionsGetPublicKey == AppPermissionsGetPublicKey {
-		s = append(s, "GETPUBLICKEY")
-	}
-	if x&AppPermissionsGetInfo == AppPermissionsGetInfo {
-		s = append(s, "GETINFO")
-	}
 	return json.Marshal(s)
 }
 
@@ -612,14 +596,6 @@ func (x *AppPermissions) UnmarshalJSON(data []byte) error {
 			*x = *x | AppPermissionsAudit
 		case "TRANSFORM":
 			*x = *x | AppPermissionsTransform
-		case "CREATEKEY":
-			*x = *x | AppPermissionsCreateKey
-		case "DESTROYKEY":
-			*x = *x | AppPermissionsDestroyKey
-		case "GETPUBLICKEY":
-			*x = *x | AppPermissionsGetPublicKey
-		case "GETINFO":
-			*x = *x | AppPermissionsGetInfo
 		}
 	}
 	return nil

--- a/sdkms/keys_generated.go
+++ b/sdkms/keys_generated.go
@@ -174,7 +174,7 @@ type ListSobjectsParams struct {
 	// Only show security objects complying with group and account policies.
 	CompliantWithPolicies *bool `json:"compliant_with_policies,omitempty"`
 	// Filter security object(s) by custom_metadata fields.
-	CustomMetadata map[string]string `json:"custom_metadata,omitempty"`
+	CustomMetadata *CustomMetadata `json:"custom_metadata,omitempty"`
 	// Display query metadata in response, containing information on total objects
 	// and number of objects skipped.
 	WithMetadata *bool `json:"with_metadata,omitempty"`
@@ -223,6 +223,9 @@ func (x ListSobjectsParams) urlEncode(v map[string][]string) error {
 	if x.CompliantWithPolicies != nil {
 		v["compliant_with_policies"] = []string{fmt.Sprintf("%v", *x.CompliantWithPolicies)}
 	}
+	if err := x.CustomMetadata.urlEncode(v); err != nil {
+		return err
+	}
 	if x.WithMetadata != nil {
 		v["with_metadata"] = []string{fmt.Sprintf("%v", *x.WithMetadata)}
 	}
@@ -243,9 +246,6 @@ func (x ListSobjectsParams) urlEncode(v map[string][]string) error {
 	}
 	if x.Filter != nil {
 		v["filter"] = []string{fmt.Sprintf("%v", *x.Filter)}
-	}
-	for k, val := range x.CustomMetadata {
-		v[fmt.Sprintf("custom_metadata.%s", k)] = []string{val}
 	}
 	return nil
 }

--- a/sdkms/keys_generated.go
+++ b/sdkms/keys_generated.go
@@ -361,13 +361,18 @@ type SobjectRekeyRequest struct {
 
 func (x SobjectRekeyRequest) MarshalJSON() ([]byte, error) {
 	m := make(map[string]interface{})
-	// Dest
-	b, err := json.Marshal(&x.Dest)
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(b, &m); err != nil {
-		return nil, err
+	{ // Dest
+		b, err := json.Marshal(&x.Dest)
+		if err != nil {
+			return nil, err
+		}
+		f := make(map[string]interface{})
+		if err := json.Unmarshal(b, &f); err != nil {
+			return nil, err
+		}
+		for k, v := range f {
+			m[k] = &v
+		}
 	}
 	m["deactivate_rotated_key"] = &x.DeactivateRotatedKey
 	return json.Marshal(&m)
@@ -436,7 +441,7 @@ type SobjectRequest struct {
 	Fpe *FpeOptions `json:"fpe,omitempty"`
 	// Key Access Justifications for GCP EKM.
 	// For more details: https://cloud.google.com/cloud-provider-access-management/key-access-justifications/docs/overview
-	GoogleAccessReasonPolicy Removable[GoogleAccessReasonPolicy] `json:"google_access_reason_policy,omitempty"`
+	GoogleAccessReasonPolicy *Removable[GoogleAccessReasonPolicy] `json:"google_access_reason_policy,omitempty"`
 	// KCDSA specific options.
 	Kcdsa *KcdsaOptions `json:"kcdsa,omitempty"`
 	// Key Checksum Value of the security object.
@@ -974,7 +979,7 @@ func (c *Client) RequestApprovalToRemovePrivate(
 //
 // For two keys R and S, where R is the key to be replaced,
 // and S is the intended replacement, this operation will
-//   - Rename R to the name provied in the request
+//   - Rename R to the name provided in the request
 //   - Establish an replaced-replacement between R and S
 //   - Assign R's old name to S
 //

--- a/sdkms/query_param_test.go
+++ b/sdkms/query_param_test.go
@@ -38,7 +38,7 @@ func Test_GetAccountParams(t *testing.T) {
 		input GetAccountParams
 		want  string
 	}{
-		{input: GetAccountParams{}, want: "with_totals=false"},
+		{input: GetAccountParams{}, want: ""},
 		{input: GetAccountParams{WithTotals: someBoolean(true)}, want: "with_totals=true"},
 	}
 	for i, tc := range tt {
@@ -100,13 +100,13 @@ func Test_ListAppsParams(t *testing.T) {
 		input ListAppsParams
 		want  string
 	}{
-		{input: ListAppsParams{}, want: "group_permissions=false"},
+		{input: ListAppsParams{}, want: ""},
 		{
 			input: ListAppsParams{
 				GroupID: someString("75814e50-41b9-4913-be93-6184294a55ea"),
 				Limit:   someUint(65),
 			},
-			want: "group_id=75814e50-41b9-4913-be93-6184294a55ea&group_permissions=false&limit=65",
+			want: "group_id=75814e50-41b9-4913-be93-6184294a55ea&limit=65",
 		},
 		{
 			input: ListAppsParams{
@@ -115,7 +115,7 @@ func Test_ListAppsParams(t *testing.T) {
 					ByAppID: &AppSortByAppId{},
 				},
 			},
-			want: "group_permissions=false&limit=65&sort=app_id",
+			want: "limit=65&sort=app_id",
 		},
 		{
 			input: ListAppsParams{
@@ -126,7 +126,7 @@ func Test_ListAppsParams(t *testing.T) {
 					},
 				},
 			},
-			want: "group_permissions=false&limit=65&sort=app_id&start=myApp",
+			want: "limit=65&sort=app_id&start=myApp",
 		},
 		{
 			input: ListAppsParams{
@@ -139,7 +139,7 @@ func Test_ListAppsParams(t *testing.T) {
 					},
 				},
 			},
-			want: "group_id=75814e50-41b9-4913-be93-6184294a55ea&group_permissions=false&limit=65&sort=app_id%3Aasc&start=myApp",
+			want: "group_id=75814e50-41b9-4913-be93-6184294a55ea&limit=65&sort=app_id%3Aasc&start=myApp",
 		},
 	}
 	for i, tc := range tt {

--- a/sdkms/support.go
+++ b/sdkms/support.go
@@ -531,3 +531,12 @@ func (r *ListSobjectsResponse) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
+
+type CustomMetadata map[string]string
+
+func (x *CustomMetadata) urlEncode(v map[string][]string) error {
+	for k, val := range *x {
+		v[fmt.Sprintf("custom_metadata.%s", k)] = []string{val}
+	}
+	return nil
+}

--- a/sdkms/support_test.go
+++ b/sdkms/support_test.go
@@ -1,0 +1,35 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package sdkms
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_CustomMetadata(t *testing.T) {
+	tt := []struct {
+		input CustomMetadata
+		want  string
+	}{
+		{input: CustomMetadata(nil), want: ""},
+		{input: CustomMetadata(map[string]string{}), want: ""},
+		{input: CustomMetadata(map[string]string{"hello": "world"}), want: "custom_metadata.hello=world"},
+		{input: CustomMetadata(map[string]string{"hello": "world", "test": "abcd"}), want: "custom_metadata.hello=world&custom_metadata.test=abcd"},
+	}
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("Encode-%v", i), func(t *testing.T) {
+			got, err := encodeURLParams(&tc.input)
+			if err != nil {
+				t.Errorf("failed to encode URL params: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Expected value %#v, got %#v", tc.want, got)
+			}
+		})
+	}
+}

--- a/sdkms/users_generated.go
+++ b/sdkms/users_generated.go
@@ -131,8 +131,6 @@ type MfaDelDeviceRequest struct {
 type MfaDevice struct {
 	// Name given to the FIDO device.
 	Name string `json:"name"`
-	// Origin of the FIDO device.
-	Origin *string `json:"origin,omitempty"`
 }
 
 // Request to rename a FIDO device.


### PR DESCRIPTION
The `GoogleAccessReasonPolicy` field in `SobjectRequest` was incorrectly typed. The custom unpublished stuff (from PRs #16, #17 and #18) which should be on a pre-release and a separate branch are also removed. Other changes are removing manual edits that were unnecessary. The new batch API was also missing which is added now.

All versions containing incorrect code are also retracted in `go.mod`