### PR TITLE
Move ListSobjectsResponse to support.go and fix its field name and type

### DIFF
--- a/sdkms/keys_generated.go
+++ b/sdkms/keys_generated.go
@@ -143,14 +143,6 @@ type KeyCheckValueResponse struct {
 	Kcv string `json:"kcv"`
 }
 
-// Response structure from list security objects query
-type ListSobjectsResponse struct {
-	// Metadata indicating filtered and total count.
-	Md Metadata `json:"metadata,omitempty"`
-	// List of security objects matching the filtering parameters.
-	Items []Sobject `json:"items,omitempty"`
-}
-
 // Request parameters for filtering and listing security objects.
 type ListSobjectsParams struct {
 	// Filter security object(s) by group ID.

--- a/sdkms/support.go
+++ b/sdkms/support.go
@@ -499,33 +499,38 @@ func (t *AuditLogTime) UnmarshalJSON(data []byte) (err error) {
 	return nil
 }
 
+// Response structure from list security objects query.
+type ListSobjectsResponse struct {
+	// Metadata indicating filtered and total count.
+	Metadata *Metadata `json:"metadata,omitempty"`
+	// List of security objects matching the filtering parameters.
+	Items []Sobject `json:"items,omitempty"`
+}
+
 func (r *ListSobjectsResponse) UnmarshalJSON(data []byte) error {
 	// Define an intermediate struct to decode the items array.
 	type response struct {
-		Md    Metadata  `json:"metadata,omitempty"`
-		Items []Sobject `json:"items,omitempty"`
+		Metadata *Metadata `json:"metadata,omitempty"`
+		Items    []Sobject `json:"items,omitempty"`
 	}
 
-	// Decode the JSON into the intermediate struct.
 	var resp1 response
-	var resp2 []Sobject
 	err1 := json.Unmarshal(data, &resp1)
-	err2 := json.Unmarshal(data, &resp2)
-
 	if err1 == nil {
 		r.Items = resp1.Items
-		r.Md = resp1.Md
+		r.Metadata = resp1.Metadata
 		return nil
 	}
 
+	var resp2 []Sobject
+	err2 := json.Unmarshal(data, &resp2)
 	if err2 == nil {
 		r.Items = resp2
+		r.Metadata = nil
 		return nil
 	}
-	if err1 != nil && err2 != nil {
-		return fmt.Errorf("Error in decoding ListSobjectResponse: %v, %v", err1, err2)
-	}
-	return nil
+
+	return fmt.Errorf("Error in decoding ListSobjectResponse: %v, %v", err1, err2)
 }
 
 type CustomMetadata map[string]string


### PR DESCRIPTION
This would be a breaking change, so perhaps we can wait for 4.21 to publish it, otherwise it warrants a 0.5.0 version.